### PR TITLE
start.sh: Max epoch change delay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,5 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    - name: Notify new Docker image
+      run: curl -X POST https://holy-bread-207a.livepeer.workers.dev


### PR DESCRIPTION
Let livepeer continue to run for a random delay before DAG generation so
that multiple processes using this script do not all stop livepeer at
the same time.