### PR TITLE
start.sh: Reformat string for --cuda-devices

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,10 +28,11 @@ start_cuda_mps_daemon() {
 
 start_ethminer() {
     echo "Starting ethminer in the background..."
+    # --cuda-devices accepts a space delimited string, but NVIDIA_DEVICES is a comma delimited string
     ethminer -U -P $POOL_ADDR --cuda-streams $CUDA_STREAMS \
         --cuda-block-size $CUDA_BLOCK_SIZE --cuda-grid-size $CUDA_GRID_SIZE \
-        --cuda-devices $NVIDIA_DEVICES \
-        --api-bind 127.0.0.1:3333 &
+        --api-bind 127.0.0.1:3333 \
+        --cuda-devices $(echo $NVIDIA_DEVICES | tr , " ") &
     ethminer_pid=$!
 }
 


### PR DESCRIPTION
--cuda-devices (ethminer) accepts a space delimited string, but NVIDIA_DEVICES is a comma delimited string. So, the script now replaces commas with spaces before passing the value to ethminer.

See [ethminer flags](https://gist.github.com/jkcdarunday/e89dde8fa71e510596f45480c5529376).

I also had to move the --cuda-devices argument after the --api-bind argument - for some reason the expression `$(echo $NVIDIA_DEVICES | tr , " ")` was only evaluated/parsed properly by ethminer with this ordering. 